### PR TITLE
Fix/handler error code & Rust Concurrency

### DIFF
--- a/docs/src/content/docs/api/rust.mdx
+++ b/docs/src/content/docs/api/rust.mdx
@@ -38,6 +38,7 @@ let registry = CommandRegistry::new(Config {
     router_channel: None,
     request_ttl: Duration::from_secs(30),
     event_ttl: Duration::from_secs(5),
+    max_in_flight_per_channel: 256,
 });
 ```
 
@@ -49,6 +50,18 @@ let registry = CommandRegistry::new(Config {
 | `router_channel` | `Option<String>` | Channel ID for escalating unknown commands |
 | `request_ttl` | `Duration` | Timeout for pending requests |
 | `event_ttl` | `Duration` | TTL for event deduplication |
+| `max_in_flight_per_channel` | `usize` | Per-channel cap on concurrently in-flight handler futures (default `256`; `0` disables) |
+
+Every field has a sensible default — call `Config::default()` or use `..Default::default()` in a struct literal and you can omit anything you don't care about:
+
+```rust
+let registry = CommandRegistry::new(Config {
+    id: Some("main".into()),
+    ..Default::default()  // fills in router_channel, request_ttl, event_ttl, max_in_flight_per_channel
+});
+```
+
+The fields are only *syntactically* required when you list them out one by one (Rust struct literals must name every field). Functionally none of them are mandatory.
 
 ### Methods
 
@@ -83,6 +96,14 @@ tokio::spawn(driver);
 ```
 
 Forgetting to spawn the driver means the registry never processes incoming messages from that channel. `dispose()` will still work (it awaits each `channel.close()`), but until then the channel is silent from the registry's point of view.
+
+### Concurrent handler dispatch
+
+Within the driver task, the pump dispatches handlers concurrently: each incoming message's handler future is pushed into a `FuturesUnordered` and cooperatively interleaved with the next `recv`. A handler that awaits external work (timer, network, forwarded call) no longer blocks subsequent messages on the same channel — fast commands, forwarded responses, and events all continue flowing.
+
+The number of simultaneously in-flight handlers on one channel is capped by `Config::max_in_flight_per_channel` (default `256`). At the cap the pump applies backpressure to the channel rather than dropping messages; set to `0` to disable the cap.
+
+This is cooperative concurrency on a single executor task, not multi-thread parallelism. For true CPU-parallel dispatch, wrap your handler body in your runtime's `spawn` (e.g. `tokio::spawn`) — the crate itself stays runtime-agnostic.
 
 ### request_ttl vs handler duration
 

--- a/rust/CHANGELOG.md
+++ b/rust/CHANGELOG.md
@@ -1,0 +1,45 @@
+# Changelog
+
+## coralstack-cmd-ipc 0.2.0
+
+### Fixes
+
+- **Concurrent handler dispatch (head-of-line blocking fix).** The
+  per-channel pump in `CommandRegistry::register_channel` previously
+  awaited each handler future inline before reading the next message,
+  which meant a single slow handler (e.g. one awaiting a multi-minute
+  external sync) would stall every subsequent message on that channel —
+  including unrelated commands, forwarded responses, and events. The
+  pump now pushes each handler future into a `FuturesUnordered` and
+  cooperatively interleaves it with the next `recv`, so awaits inside a
+  handler no longer block other messages.
+
+  The fix is runtime-agnostic: no `tokio::spawn`, no new dependency,
+  no API break. The user's existing executor still drives the single
+  pump task. For true multi-thread parallelism, wrap handler bodies
+  in your runtime's `spawn` yourself.
+
+- **Preserve the wire error message on `NotFound`.**
+  `error_to_command_error` previously substituted the local command id
+  into `CommandError::NotFound`, discarding the message the remote
+  peer sent (e.g. the full `Command "x" not found` text). It now
+  propagates the wire message verbatim, so callers see what the peer
+  actually reported. Paired with the TypeScript fix that stops
+  labelling every handler exception as `NOT_FOUND` and now defaults
+  handler runtime failures to `INTERNAL_ERROR`, the Rust client no
+  longer surfaces misleading "not found" errors for handlers that
+  simply threw.
+
+### Added
+
+- **`Config::max_in_flight_per_channel`** (default `256`, set by
+  `Config::default()`). Caps the number of handler futures the pump
+  will let run concurrently on one channel. When the cap is reached
+  the pump applies backpressure to the channel rather than dropping
+  messages. Set to `0` to disable the cap.
+
+  Optional in practice — code using `Config::default()` or
+  `..Default::default()` picks up the `256` default automatically.
+  The field only needs an explicit value when you construct
+  `Config { … }` field-by-field, because Rust struct literals must
+  name every field.

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -84,7 +84,7 @@ dependencies = [
 
 [[package]]
 name = "coralstack-cmd-ipc"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "coralstack-cmd-ipc-macros",
  "futures",
@@ -98,7 +98,7 @@ dependencies = [
 
 [[package]]
 name = "coralstack-cmd-ipc-macros"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -107,7 +107,7 @@ dependencies = [
 
 [[package]]
 name = "coralstack-cmd-ipc-mcp"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "coralstack-cmd-ipc",
  "futures",
@@ -132,7 +132,7 @@ checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "dynamic-plugin"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "coralstack-cmd-ipc",
  "futures",
@@ -394,7 +394,7 @@ dependencies = [
 
 [[package]]
 name = "multi-service"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "coralstack-cmd-ipc",
  "futures",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*", "examples/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.1"
+version = "0.2.0"
 edition = "2021"
 rust-version = "1.75"
 license = "MIT"

--- a/rust/crates/cmd-ipc-mcp/Cargo.toml
+++ b/rust/crates/cmd-ipc-mcp/Cargo.toml
@@ -12,7 +12,7 @@ keywords = ["mcp", "ipc", "agents", "tools"]
 categories = ["api-bindings", "asynchronous"]
 
 [dependencies]
-coralstack-cmd-ipc = { path = "../cmd-ipc", version = "0.1.0" }
+coralstack-cmd-ipc = { path = "../cmd-ipc", version = "0.2.0" }
 rmcp = { version = "1.5", default-features = false, features = ["server", "transport-io"] }
 tokio = { version = "1", features = ["rt", "macros", "io-util"] }
 serde.workspace = true

--- a/rust/crates/cmd-ipc/Cargo.toml
+++ b/rust/crates/cmd-ipc/Cargo.toml
@@ -19,7 +19,7 @@ futures.workspace = true
 uuid.workspace = true
 thiserror.workspace = true
 parking_lot.workspace = true
-coralstack-cmd-ipc-macros = { path = "../cmd-ipc-macros", version = "0.1.0" }
+coralstack-cmd-ipc-macros = { path = "../cmd-ipc-macros", version = "0.2.0" }
 
 [dev-dependencies]
 futures = { workspace = true, features = ["executor", "thread-pool"] }

--- a/rust/crates/cmd-ipc/src/registry.rs
+++ b/rust/crates/cmd-ipc/src/registry.rs
@@ -26,7 +26,8 @@ use std::time::Duration;
 
 use futures::channel::oneshot;
 use futures::future::BoxFuture;
-use futures::FutureExt;
+use futures::stream::FuturesUnordered;
+use futures::{FutureExt, StreamExt};
 use parking_lot::Mutex;
 use serde::Serialize;
 use serde_json::Value;
@@ -55,6 +56,20 @@ pub struct Config {
     pub request_ttl: Duration,
     /// How long a seen event id is remembered for dedup purposes.
     pub event_ttl: Duration,
+    /// Maximum number of handler futures that may be in flight
+    /// concurrently on a single channel's pump. Once this cap is
+    /// reached, the pump stops pulling new messages off the channel
+    /// (applying upstream backpressure) until an in-flight handler
+    /// finishes. `0` disables the cap.
+    ///
+    /// **Optional in practice** — `Config::default()` sets this to
+    /// `256`, so callers using `..Default::default()` never need to
+    /// supply it. It is only *syntactically* required when you build
+    /// `Config { … }` field-by-field (Rust struct literals must list
+    /// every field). The cap exists so a misbehaving peer can't cause
+    /// unbounded handler-future buildup; the default is fine for
+    /// almost every workload.
+    pub max_in_flight_per_channel: usize,
 }
 
 impl Default for Config {
@@ -64,6 +79,7 @@ impl Default for Config {
             router_channel: None,
             request_ttl: Duration::from_secs(30),
             event_ttl: Duration::from_secs(5),
+            max_in_flight_per_channel: 256,
         }
     }
 }
@@ -125,6 +141,8 @@ struct Inner {
     event_listeners: Mutex<HashMap<String, BTreeMap<u64, EventListener>>>,
     /// Monotonically-increasing token used to key event listeners.
     next_listener_token: AtomicU64,
+    /// Per-channel in-flight cap, copied from [`Config`].
+    max_in_flight_per_channel: usize,
 }
 
 /// The main entry point of the crate.
@@ -171,6 +189,7 @@ impl CommandRegistry {
             seen_events: TtlMap::new(cfg.event_ttl),
             event_listeners: Mutex::new(HashMap::new()),
             next_listener_token: AtomicU64::new(0),
+            max_in_flight_per_channel: cfg.max_in_flight_per_channel,
         });
         Self { inner }
     }
@@ -340,6 +359,18 @@ impl CommandRegistry {
     /// `futures::executor::block_on`, …) for the registry to exchange
     /// messages with the peer. The future completes when the channel
     /// closes.
+    ///
+    /// Handler dispatch is **concurrent within the driver task**: the
+    /// pump pushes each incoming message's handler future into a
+    /// [`FuturesUnordered`] and cooperatively interleaves them with
+    /// the next `recv`, so a slow handler that awaits external work
+    /// no longer blocks subsequent messages on the same channel. The
+    /// number of simultaneously in-flight handlers is capped by
+    /// [`Config::max_in_flight_per_channel`] (default 256); at the
+    /// cap the pump applies backpressure to the channel rather than
+    /// dropping messages. For true multi-thread parallelism, wrap
+    /// the handler body in your runtime's `spawn` (e.g.
+    /// `tokio::spawn`) — the crate itself stays runtime-agnostic.
     pub async fn register_channel(
         &self,
         channel: Arc<dyn CommandChannel>,
@@ -369,7 +400,31 @@ impl CommandRegistry {
         let inner = self.inner.clone();
         let ch = channel;
         Ok(async move {
-            while let Some(msg) = ch.recv().await {
+            // In-flight handler futures cooperatively interleaved with
+            // message recv. This is what makes the pump non-blocking:
+            // when one handler awaits (sleep / network / forwarded
+            // call), the executor polls other handlers and the recv
+            // future on the same task, so a slow handler can no
+            // longer wedge every subsequent message behind it.
+            //
+            // Stays runtime-agnostic (no `tokio::spawn`); the user's
+            // executor still owns the single task driving this pump.
+            // True multi-thread parallelism is possible if the user
+            // wraps their handler body in `tokio::spawn` themselves.
+            let mut in_flight: FuturesUnordered<BoxFuture<'static, ()>> = FuturesUnordered::new();
+            let cap = inner.max_in_flight_per_channel;
+
+            loop {
+                // Backpressure: while at capacity, drain in-flight
+                // handlers instead of accepting new messages. Ordering
+                // of message *reception* is preserved — only dispatch
+                // fans out. Messages are never dropped.
+                while cap > 0 && in_flight.len() >= cap {
+                    if in_flight.next().await.is_none() {
+                        break;
+                    }
+                }
+
                 // Opportunistic TTL sweep: any registry activity
                 // triggers a pass over the pending-reply / route maps
                 // so timed-out entries fire their on_expire callbacks
@@ -378,8 +433,34 @@ impl CommandRegistry {
                 inner.execute_replies.sweep_expired();
                 inner.register_replies.sweep_expired();
                 inner.routes.sweep_expired();
-                Inner::handle_message(inner.clone(), ch.clone(), msg).await;
+
+                // Wait for either the next message OR for an in-flight
+                // handler to make progress. When `in_flight` is empty
+                // we'd otherwise busy-loop on its `.next()` returning
+                // `None`, so park on `pending()` in that case.
+                let next_msg = if in_flight.is_empty() {
+                    ch.recv().await
+                } else {
+                    futures::select_biased! {
+                        // Drain finished handlers so the in_flight set
+                        // shrinks promptly. `select_next_some` skips
+                        // the empty case, but we've already guarded
+                        // against that above.
+                        _ = in_flight.select_next_some() => continue,
+                        msg = ch.recv().fuse() => msg,
+                    }
+                };
+
+                let Some(msg) = next_msg else { break };
+                in_flight.push(Inner::handle_message(inner.clone(), ch.clone(), msg).boxed());
             }
+
+            // Channel closed — drain any in-flight handlers so their
+            // outgoing responses are sent before we tear the channel
+            // state down. Handlers that try to `send` on the now-closed
+            // channel will get `Err(Closed)` from the transport, which
+            // is the existing semantics.
+            while in_flight.next().await.is_some() {}
             Inner::handle_channel_close(&inner, ch.id());
         })
     }

--- a/rust/crates/cmd-ipc/src/registry.rs
+++ b/rust/crates/cmd-ipc/src/registry.rs
@@ -1162,7 +1162,7 @@ fn command_error_to_execute(e: &CommandError, command_id: &str) -> ExecuteError 
 
 fn error_to_command_error(err: ExecuteError, command_id: &str) -> CommandError {
     match err.code {
-        ExecuteErrorCode::NotFound => CommandError::NotFound(command_id.into()),
+        ExecuteErrorCode::NotFound => CommandError::NotFound(err.message),
         ExecuteErrorCode::InvalidRequest => CommandError::InvalidRequest {
             command_id: command_id.into(),
             message: err.message,

--- a/rust/crates/cmd-ipc/tests/concurrency.rs
+++ b/rust/crates/cmd-ipc/tests/concurrency.rs
@@ -1,0 +1,437 @@
+//! Tests for the per-channel pump's concurrent handler dispatch.
+//!
+//! Pre-0.2.1 the pump awaited each handler future inline, so a single
+//! slow handler stalled every subsequent message on the same channel.
+//! These tests pin the post-fix behavior: handler futures are
+//! cooperatively interleaved with `recv`, ordering of responses follows
+//! handler completion (not arrival), and `Config::max_in_flight_per_channel`
+//! applies backpressure without dropping messages.
+
+use std::future::Future;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use coralstack_cmd_ipc::{
+    Command, CommandChannel, CommandError, CommandRegistry, Config, DynEvent, InMemoryChannel,
+};
+use futures::channel::oneshot;
+use futures::executor::{block_on, ThreadPool};
+use futures::future::join_all;
+use futures::lock::Mutex as AsyncMutex;
+use futures::task::SpawnExt;
+use futures::FutureExt;
+use serde::{Deserialize, Serialize};
+use serde_json::json;
+
+// ---------- shared helpers ----------
+
+fn sleep_ms(ms: u64) -> impl Future<Output = ()> {
+    let (tx, rx) = oneshot::channel();
+    std::thread::spawn(move || {
+        std::thread::sleep(Duration::from_millis(ms));
+        let _ = tx.send(());
+    });
+    async move {
+        let _ = rx.await;
+    }
+}
+
+fn config(id: &str, router: Option<&str>) -> Config {
+    Config {
+        id: Some(id.into()),
+        router_channel: router.map(String::from),
+        request_ttl: Duration::from_secs(10),
+        event_ttl: Duration::from_secs(2),
+        max_in_flight_per_channel: 256,
+    }
+}
+
+fn config_with_cap(id: &str, router: Option<&str>, cap: usize) -> Config {
+    let mut c = config(id, router);
+    c.max_in_flight_per_channel = cap;
+    c
+}
+
+/// Wires two registries together (root `a` ↔ child `b` with router `a`),
+/// spawning each pump driver on the supplied thread pool. The returned
+/// channels are kept alive by the caller so the drivers don't shut down
+/// prematurely.
+fn wire(
+    cfg_a: Config,
+    cfg_b: Config,
+    pool: &ThreadPool,
+) -> (
+    CommandRegistry,
+    CommandRegistry,
+    Arc<dyn CommandChannel>,
+    Arc<dyn CommandChannel>,
+) {
+    let a_id = cfg_a.id.clone().unwrap();
+    let b_id = cfg_b.id.clone().unwrap();
+    let (ch_for_a, ch_for_b) = InMemoryChannel::pair(b_id.clone(), a_id.clone());
+    let ch_for_a: Arc<dyn CommandChannel> = ch_for_a;
+    let ch_for_b: Arc<dyn CommandChannel> = ch_for_b;
+    let reg_a = CommandRegistry::new(cfg_a);
+    let reg_b = CommandRegistry::new(cfg_b);
+    block_on(async {
+        let drv_a = reg_a.register_channel(ch_for_a.clone()).await.unwrap();
+        let drv_b = reg_b.register_channel(ch_for_b.clone()).await.unwrap();
+        pool.spawn(drv_a).unwrap();
+        pool.spawn(drv_b).unwrap();
+    });
+    (reg_a, reg_b, ch_for_a, ch_for_b)
+}
+
+// ---------- test commands ----------
+
+struct SlowCmd;
+
+#[derive(Deserialize, Serialize)]
+struct SleepReq {
+    ms: u64,
+    tag: String,
+}
+
+#[derive(Deserialize, Serialize, Debug, PartialEq)]
+struct TaggedResp {
+    tag: String,
+    finished_at_ms: u64,
+}
+
+impl Command for SlowCmd {
+    const ID: &'static str = "slow";
+    type Request = SleepReq;
+    type Response = TaggedResp;
+
+    async fn handle(&self, req: SleepReq) -> Result<TaggedResp, CommandError> {
+        let start = Instant::now();
+        sleep_ms(req.ms).await;
+        Ok(TaggedResp {
+            tag: req.tag,
+            finished_at_ms: start.elapsed().as_millis() as u64,
+        })
+    }
+}
+
+struct FastCmd;
+
+impl Command for FastCmd {
+    const ID: &'static str = "fast";
+    type Request = String;
+    type Response = String;
+
+    async fn handle(&self, req: String) -> Result<String, CommandError> {
+        Ok(format!("got:{req}"))
+    }
+}
+
+/// Handler whose entry/exit is observable, and which blocks until a
+/// shared barrier oneshot fires. Used to drive the backpressure test
+/// deterministically.
+struct BarrierCmd {
+    counter: Arc<AtomicUsize>,
+    high_water: Arc<AtomicUsize>,
+    release: Arc<AsyncMutex<Option<futures::future::Shared<oneshot::Receiver<()>>>>>,
+}
+
+impl Command for BarrierCmd {
+    const ID: &'static str = "barrier";
+    type Request = ();
+    type Response = ();
+
+    async fn handle(&self, _req: ()) -> Result<(), CommandError> {
+        let now = self.counter.fetch_add(1, Ordering::SeqCst) + 1;
+        // Track high-water mark of concurrent handlers.
+        let mut prev = self.high_water.load(Ordering::SeqCst);
+        while now > prev {
+            match self
+                .high_water
+                .compare_exchange(prev, now, Ordering::SeqCst, Ordering::SeqCst)
+            {
+                Ok(_) => break,
+                Err(cur) => prev = cur,
+            }
+        }
+        // Wait on the shared release signal.
+        let rx = self.release.lock().await.as_ref().cloned();
+        if let Some(rx) = rx {
+            let _ = rx.await;
+        }
+        self.counter.fetch_sub(1, Ordering::SeqCst);
+        Ok(())
+    }
+}
+
+// ---------- tests ----------
+
+/// Test 1 — Concurrent dispatch: a fast command issued after a slow
+/// one returns first. Pre-fix the fast call waited for the slow one.
+#[test]
+fn fast_command_does_not_wait_for_slow_one() {
+    let pool = ThreadPool::new().unwrap();
+    let (reg_a, reg_b, _ca, _cb) = wire(config("a", None), config("b", Some("a")), &pool);
+
+    block_on(async {
+        reg_a.register_command(SlowCmd).await.unwrap();
+        reg_a.register_command(FastCmd).await.unwrap();
+
+        // Kick off slow first, then fast. From b's pov both are remote.
+        let slow_fut = reg_b.execute::<SlowCmd>(SleepReq {
+            ms: 300,
+            tag: "slow".into(),
+        });
+        // Yield once so the slow request gets onto the wire first.
+        sleep_ms(20).await;
+        let fast_fut = reg_b.execute::<FastCmd>("hi".to_string());
+
+        let started = Instant::now();
+        let fast = fast_fut.await.unwrap();
+        let fast_elapsed = started.elapsed();
+        assert_eq!(fast, "got:hi");
+        // Fast must complete well before the slow handler's sleep
+        // elapses. Be generous: 200ms cushion under the 300ms sleep.
+        assert!(
+            fast_elapsed < Duration::from_millis(250),
+            "fast call took {fast_elapsed:?}, head-of-line blocked by slow handler"
+        );
+
+        let slow = slow_fut.await.unwrap();
+        assert_eq!(slow.tag, "slow");
+    });
+}
+
+/// Test 2 — Backpressure cap. With `max_in_flight_per_channel = 4`,
+/// firing 10 long-running requests must produce at most 4 concurrent
+/// handlers at the high-water mark; all 10 complete once released.
+#[test]
+fn backpressure_cap_limits_concurrent_handlers() {
+    let pool = ThreadPool::new().unwrap();
+    // Root caps in-flight handlers at 4. Child is unbounded.
+    let (reg_a, reg_b, _ca, _cb) =
+        wire(config_with_cap("a", None, 4), config("b", Some("a")), &pool);
+
+    let counter = Arc::new(AtomicUsize::new(0));
+    let high_water = Arc::new(AtomicUsize::new(0));
+    let (release_tx, release_rx) = oneshot::channel::<()>();
+    let release_shared = release_rx.shared();
+    let release_slot = Arc::new(AsyncMutex::new(Some(release_shared)));
+
+    block_on(async {
+        reg_a
+            .register_command(BarrierCmd {
+                counter: counter.clone(),
+                high_water: high_water.clone(),
+                release: release_slot,
+            })
+            .await
+            .unwrap();
+
+        // Fire 10 in parallel — must spawn so futures actually get
+        // polled while we observe the high-water mark.
+        let mut handles = Vec::new();
+        for _ in 0..10 {
+            let reg = reg_b.clone();
+            let h = pool
+                .spawn_with_handle(async move { reg.execute_dyn("barrier", json!(null)).await })
+                .unwrap();
+            handles.push(h);
+        }
+
+        // Give the registry a chance to start dispatching and saturate
+        // the in-flight cap.
+        sleep_ms(300).await;
+        let hw = high_water.load(Ordering::SeqCst);
+        assert!(hw > 0, "no handler ever started");
+        assert!(hw <= 4, "high water {hw} exceeds cap of 4");
+
+        // Release the barrier and let them all finish.
+        let _ = release_tx.send(());
+        let results = join_all(handles).await;
+        for r in results {
+            r.unwrap();
+        }
+        assert_eq!(counter.load(Ordering::SeqCst), 0);
+    });
+}
+
+/// Test 3 — Response correlation by `thid`. Mixed slow/fast requests
+/// must each receive their own response, regardless of completion
+/// order.
+#[test]
+fn responses_match_originating_requests() {
+    let pool = ThreadPool::new().unwrap();
+    let (reg_a, reg_b, _ca, _cb) = wire(config("a", None), config("b", Some("a")), &pool);
+
+    block_on(async {
+        reg_a.register_command(SlowCmd).await.unwrap();
+
+        // Mix sleeps so responses arrive out-of-order.
+        let pattern: Vec<(u64, &'static str)> = vec![
+            (200, "A"),
+            (10, "B"),
+            (150, "C"),
+            (5, "D"),
+            (80, "E"),
+            (40, "F"),
+            (20, "G"),
+            (120, "H"),
+            (1, "I"),
+            (60, "J"),
+        ];
+        let futs: Vec<_> = pattern
+            .iter()
+            .map(|(ms, tag)| {
+                reg_b.execute::<SlowCmd>(SleepReq {
+                    ms: *ms,
+                    tag: (*tag).to_string(),
+                })
+            })
+            .collect();
+        let results = join_all(futs).await;
+        for ((_, expected_tag), res) in pattern.iter().zip(results.iter()) {
+            let r = res.as_ref().unwrap();
+            assert_eq!(&r.tag, *expected_tag, "thid correlation failed");
+        }
+    });
+}
+
+/// Test 4 — Event fan-out is not blocked by an in-flight slow handler.
+#[test]
+fn events_flow_while_slow_handler_in_flight() {
+    let pool = ThreadPool::new().unwrap();
+    let (reg_a, reg_b, _ca, _cb) = wire(config("a", None), config("b", Some("a")), &pool);
+
+    let received = Arc::new(AtomicUsize::new(0));
+    {
+        let received = received.clone();
+        // Listen on reg_a; events emit from reg_b and cross the channel.
+        std::mem::forget(reg_a.on_dyn("tick", move |_| {
+            received.fetch_add(1, Ordering::SeqCst);
+        }));
+    }
+
+    block_on(async {
+        reg_a.register_command(SlowCmd).await.unwrap();
+        // Start a slow handler; don't await yet.
+        let slow_fut = reg_b.execute::<SlowCmd>(SleepReq {
+            ms: 400,
+            tag: "slow".into(),
+        });
+
+        // While the handler is running on reg_a, emit 100 events from
+        // reg_b. The listener on reg_a should see them all without
+        // waiting for the handler.
+        sleep_ms(30).await;
+        for _ in 0..100 {
+            reg_b.emit(DynEvent::new("tick", json!(null))).unwrap();
+        }
+
+        // Wait briefly for delivery — well under the slow handler's sleep.
+        for _ in 0..20 {
+            if received.load(Ordering::SeqCst) == 100 {
+                break;
+            }
+            sleep_ms(10).await;
+        }
+        let count = received.load(Ordering::SeqCst);
+        assert_eq!(
+            count, 100,
+            "events stalled behind handler: only {count}/100"
+        );
+
+        // Finish the slow handler cleanly.
+        let _ = slow_fut.await.unwrap();
+    });
+}
+
+/// Test 5 — Channel close while a slow handler is running: no panics,
+/// no orphan messages. The slow handler's response either lands before
+/// close or is silently dropped when send hits a closed channel.
+#[test]
+fn channel_close_during_slow_handler_is_clean() {
+    let pool = ThreadPool::new().unwrap();
+    let (reg_a, reg_b, _ca, cb) = wire(config("a", None), config("b", Some("a")), &pool);
+
+    block_on(async {
+        reg_a.register_command(SlowCmd).await.unwrap();
+
+        let slow_fut = reg_b.execute::<SlowCmd>(SleepReq {
+            ms: 300,
+            tag: "slow".into(),
+        });
+
+        // Give the handler a moment to start, then close the child's
+        // side of the channel.
+        sleep_ms(50).await;
+        cb.close().await;
+
+        // The pending execute must resolve to ChannelDisconnected (the
+        // pump's close path fires Err on every in-flight execute_reply).
+        let err = slow_fut.await.unwrap_err();
+        assert!(
+            matches!(err, CommandError::ChannelDisconnected),
+            "expected ChannelDisconnected, got {err:?}"
+        );
+
+        // Let the slow handler finish on the other side. Its `origin.send`
+        // will hit a closed channel and return Err — silently swallowed.
+        sleep_ms(400).await;
+    });
+}
+
+/// Test 6 — Regression for forward_execute: a forwarded slow remote
+/// command must not block a forwarded fast one issued just after it.
+#[test]
+fn forward_execute_does_not_serialize_remote_calls() {
+    let pool = ThreadPool::new().unwrap();
+    // Three-node setup: root `a`, child `b` (router=a), child `c` (router=a).
+    // Slow command lives on `a`; both `b` and `c` invoke it.
+    let (ch_b_for_a, ch_a_for_b) = InMemoryChannel::pair("b", "a");
+    let (ch_c_for_a, ch_a_for_c) = InMemoryChannel::pair("c", "a");
+    let ch_b_for_a: Arc<dyn CommandChannel> = ch_b_for_a;
+    let ch_a_for_b: Arc<dyn CommandChannel> = ch_a_for_b;
+    let ch_c_for_a: Arc<dyn CommandChannel> = ch_c_for_a;
+    let ch_a_for_c: Arc<dyn CommandChannel> = ch_a_for_c;
+
+    let reg_a = CommandRegistry::new(config("a", None));
+    let reg_b = CommandRegistry::new(config("b", Some("a")));
+    let reg_c = CommandRegistry::new(config("c", Some("a")));
+
+    block_on(async {
+        let drv = reg_a.register_channel(ch_b_for_a.clone()).await.unwrap();
+        pool.spawn(drv).unwrap();
+        let drv = reg_a.register_channel(ch_c_for_a.clone()).await.unwrap();
+        pool.spawn(drv).unwrap();
+        let drv = reg_b.register_channel(ch_a_for_b.clone()).await.unwrap();
+        pool.spawn(drv).unwrap();
+        let drv = reg_c.register_channel(ch_a_for_c.clone()).await.unwrap();
+        pool.spawn(drv).unwrap();
+
+        reg_a.register_command(SlowCmd).await.unwrap();
+
+        // Allow command advertisement to propagate.
+        sleep_ms(100).await;
+
+        let slow = reg_b.execute::<SlowCmd>(SleepReq {
+            ms: 300,
+            tag: "slow".into(),
+        });
+        sleep_ms(20).await;
+        let started = Instant::now();
+        let fast = reg_c
+            .execute::<SlowCmd>(SleepReq {
+                ms: 10,
+                tag: "fast".into(),
+            })
+            .await
+            .unwrap();
+        let fast_elapsed = started.elapsed();
+        assert_eq!(fast.tag, "fast");
+        assert!(
+            fast_elapsed < Duration::from_millis(250),
+            "fast forwarded call took {fast_elapsed:?}, blocked by slow forwarded call"
+        );
+        let _ = slow.await.unwrap();
+    });
+}

--- a/rust/crates/cmd-ipc/tests/conformance.rs
+++ b/rust/crates/cmd-ipc/tests/conformance.rs
@@ -494,6 +494,7 @@ fn run_behavior_vector(file: &Path, pool: &ThreadPool) -> Result<(), String> {
         router_channel,
         request_ttl: Duration::from_secs(5),
         event_ttl: Duration::from_secs(5),
+        max_in_flight_per_channel: 256,
     });
 
     // Pre-register local commands.

--- a/rust/crates/cmd-ipc/tests/dynamic_integration.rs
+++ b/rust/crates/cmd-ipc/tests/dynamic_integration.rs
@@ -27,6 +27,7 @@ fn config(id: &str, router: Option<&str>) -> Config {
         router_channel: router.map(String::from),
         request_ttl: Duration::from_secs(5),
         event_ttl: Duration::from_secs(5),
+        max_in_flight_per_channel: 256,
     }
 }
 

--- a/rust/crates/cmd-ipc/tests/macro_integration.rs
+++ b/rust/crates/cmd-ipc/tests/macro_integration.rs
@@ -65,6 +65,7 @@ fn config(id: &str, router: Option<&str>) -> Config {
         router_channel: router.map(String::from),
         request_ttl: Duration::from_secs(5),
         event_ttl: Duration::from_secs(5),
+        max_in_flight_per_channel: 256,
     }
 }
 

--- a/rust/crates/cmd-ipc/tests/registry_integration.rs
+++ b/rust/crates/cmd-ipc/tests/registry_integration.rs
@@ -75,6 +75,7 @@ fn config(id: &str, router: Option<&str>) -> Config {
         router_channel: router.map(String::from),
         request_ttl: Duration::from_secs(5),
         event_ttl: Duration::from_secs(5),
+        max_in_flight_per_channel: 256,
     }
 }
 

--- a/rust/examples/dynamic-plugin/src/main.rs
+++ b/rust/examples/dynamic-plugin/src/main.rs
@@ -344,6 +344,7 @@ fn main() {
         router_channel: None,
         request_ttl: Duration::from_secs(5),
         event_ttl: Duration::from_secs(5),
+        max_in_flight_per_channel: 256,
     });
 
     // Create the plugin channel and wire it into the registry. The

--- a/rust/examples/multi-service/src/main.rs
+++ b/rust/examples/multi-service/src/main.rs
@@ -41,12 +41,14 @@ fn setup() -> (CommandRegistry, CommandRegistry, ThreadPool) {
         router_channel: None,
         request_ttl: Duration::from_secs(30),
         event_ttl: Duration::from_secs(5),
+        max_in_flight_per_channel: 256,
     };
     let worker_cfg = Config {
         id: Some("worker".into()),
         router_channel: Some("root".into()),
         request_ttl: Duration::from_secs(30),
         event_ttl: Duration::from_secs(5),
+        max_in_flight_per_channel: 256,
     };
 
     let (ch_for_root, ch_for_worker) = InMemoryChannel::pair("worker", "root");

--- a/ts/packages/cmd-ipc-mcp/package.json
+++ b/ts/packages/cmd-ipc-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coralstack/cmd-ipc-mcp",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "MCP (Model Context Protocol) channel implementation for @coralstack/cmd-ipc",
   "keywords": [],
   "author": {

--- a/ts/packages/cmd-ipc/package.json
+++ b/ts/packages/cmd-ipc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coralstack/cmd-ipc",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "A Command IPC framework for multi-process applications and agents",
   "keywords": [],
   "author": {

--- a/ts/packages/cmd-ipc/src/registry/command-registry.ts
+++ b/ts/packages/cmd-ipc/src/registry/command-registry.ts
@@ -473,9 +473,20 @@ export class CommandRegistry<
               }
             }
             // We are root and command not found
-            throw new Error(`Command "${message.commandId}" not found`)
+            throw new CommandNotFoundError(`Command "${message.commandId}" not found`)
           }
         } catch (error) {
+          // Preserve error code if it's a known registry error, otherwise
+          // default to INTERNAL_ERROR for handler / runtime failures.
+          const code =
+            error instanceof Error &&
+            'code' in error &&
+            typeof (error as { code: unknown }).code === 'string' &&
+            (Object.values(ExecuteCommandResponseErrorCode) as string[]).includes(
+              (error as { code: string }).code,
+            )
+              ? ((error as { code: string }).code as ExecuteCommandResponseErrorCode)
+              : ExecuteCommandResponseErrorCode.INTERNAL_ERROR
           channel.sendMessage({
             id: crypto.randomUUID(),
             type: MessageType.EXECUTE_COMMAND_RESPONSE,
@@ -483,7 +494,7 @@ export class CommandRegistry<
             response: {
               ok: false,
               error: {
-                code: ExecuteCommandResponseErrorCode.NOT_FOUND,
+                code,
                 message: (error as Error).message,
               },
             },


### PR DESCRIPTION
Two bug fixes:

1. **[TypeScript & Rust] Command Error Handling.** The TypeScript registry was returning NotFound for all handler errors and the Rust library was swallowing the error message for NotFound errors. Both are now fixed so the TypeScript now returns the correct error type/code and Rust library doesn't swallow the error message when a NotFound error is returned either
2. **[RUST] Concurrent handler dispatch (head-of-line blocking fix).** The per-channel pump in `CommandRegistry::register_channel` previously awaited each handler future inline before reading the next message,  which meant a single slow handler (e.g. one awaiting a multi-minute external sync) would stall every subsequent message on that channel — including unrelated commands, forwarded responses, and events. The pump now pushes each handler future into a `FuturesUnordered` and cooperatively interleaves it with the next `recv`, so awaits inside a handler no longer block other messages.